### PR TITLE
Enable stack traces to be conditionally output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ name = "surrealdb"
 version = "0.0.0"
 dependencies = [
  "chrono",
+ "console_error_panic_hook",
  "dmp",
  "fern",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,11 @@ kv-indxdb = ["surrealdb/kv-indxdb"]
 kv-mem = ["surrealdb/kv-mem"]
 http = ["surrealdb/http"]
 rustls = ["surrealdb/rustls"]
+stack-traces = ["console_error_panic_hook"]
 
 [dependencies]
 chrono = { version = "0.4.24", features = ["serde", "wasmbind"] }
+console_error_panic_hook = { version = "0.1.7", optional = true }
 dmp = "0.2.0"
 fern = "0.6.2"
 log = "0.4.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ kv-indxdb = ["surrealdb/kv-indxdb"]
 kv-mem = ["surrealdb/kv-mem"]
 http = ["surrealdb/http"]
 rustls = ["surrealdb/rustls"]
-stack-traces = ["console_error_panic_hook"]
+stack-traces = ["dep:console_error_panic_hook"]
 
 [dependencies]
 chrono = { version = "0.4.24", features = ["serde", "wasmbind"] }

--- a/src/app/log.rs
+++ b/src/app/log.rs
@@ -3,6 +3,10 @@ use log::Record;
 use web_sys::console;
 
 pub fn init() {
+	// Display stack traces if enabled
+	#[cfg(feature = "stack-traces")]
+	console_error_panic_hook::set_once();
+	// Ensure logs are output accordingly
 	let mut logger = fern::Dispatch::new();
 	logger = logger.level_for("surrealdb", log::LevelFilter::Trace);
 	logger = logger.level(log::LevelFilter::Trace);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,7 +20,7 @@ use wasm_bindgen::prelude::*;
 
 pub use crate::err::Error;
 
-#[wasm_bindgen]
+#[wasm_bindgen(start)]
 pub fn setup() {
 	self::log::init();
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Debugging internal Rust panics in WebAssembly can be quite hard. Especially when building for release mode, with the intention of having small binary sizes.

## What does this change do?

Adds a feature flag `stack-traces` which can be used when building (in development, or even in release mode), which will output proper error messages, to the console, with full stack tracing, when Rust code panics.

This *could* be enabled for release builds, but it adds a slight increase to the file size, so it is important to test the difference and determine whether it is negligible or not.

As an example, to build in release mode with full stack traces enabled you would do:

```bash
wasm-pack build --release --target deno --out-name index --out-dir compiled/full --no-default-features --features protocol-ws,protocol-http,kv-indxdb,kv-mem,rustls,stack-traces
```

## What is your testing strategy?

No testing for this feature per-se.

## Is this related to any issues?

Closes #3 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
