### PR TITLE
Add NodeJS compatibilty

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -1,0 +1,42 @@
+import * as esbuild from "esbuild";
+import copyFilePlugin from 'esbuild-plugin-copy-file';
+import fs from 'fs';
+
+const shimContent = new Buffer.from(await fs.readFileSync('./build/shim.js'));
+const targets = ['full', 'ws', 'http'];
+
+await Promise.all(targets.map(build));
+
+async function build(target) {
+	await applyShim(target);
+	await bundle(target);
+}
+
+async function applyShim(target) {
+	let content = fs.readFileSync(`compiled/${target}/index.js`);
+	content = shimContent + content;
+	fs.writeFileSync(`compiled/${target}/shimmed.js`, content)
+}
+
+async function bundle(target) {
+	await esbuild.build({
+		entryPoints: [`compiled/${target}/shimmed.js`],
+		sourcemap: true,
+		bundle: true,
+		format: "esm",
+		platform: 'node',
+		outfile: `dist/${target}/index.js`,
+		plugins: [
+			copyFilePlugin({
+				after: Object.fromEntries(
+					["index_bg.wasm", "index_bg.wasm.d.ts", "index.d.ts"].map(
+						(f) => [
+							`compiled/${target}/${f}`,
+							`dist/${target}/${f}`,
+						]
+					)
+				),
+			}),
+		],
+	});
+}

--- a/build/shim.js
+++ b/build/shim.js
@@ -1,3 +1,6 @@
+// We need a file reading API that works with NodeJS. This API is not used in the browser, but is used in Deno and Node.
+// Use the global Deno variable if already available
+// Otherwise create a custom object for the readFile function which uses Node's "fs" api under the hood.
 const Deno =
 	globalThis.Deno ?? (
 		typeof global === 'undefined'
@@ -7,6 +10,7 @@ const Deno =
 			}
 	)
 
+// Provide a custom require function to the WASM engine. If the crypto module is not available globally, we need to pass it though manually
 const module = await (async () => {
 	const crypto = globalThis.crypto ?? await import('node:crypto');
 	return {

--- a/build/shim.js
+++ b/build/shim.js
@@ -1,0 +1,18 @@
+const Deno =
+	globalThis.Deno ?? (
+		typeof global === 'undefined'
+			? undefined
+			: {
+				readFile: (await import('node:fs')).readFileSync
+			}
+	)
+
+const module = await (async () => {
+	const crypto = globalThis.crypto ?? await import('node:crypto');
+	return {
+		require: (string) => {
+			if(string !== "crypto") throw new Error("Unexpected require " + string)
+			return crypto
+		}
+	};
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "surrealdb.wasm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealdb.wasm",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
-        "esbuild": "^0.17.19"
+        "esbuild": "^0.17.19",
+        "esbuild-plugin-copy-file": "^0.0.2"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -399,6 +400,12 @@
         "@esbuild/win32-ia32": "0.17.19",
         "@esbuild/win32-x64": "0.17.19"
       }
+    },
+    "node_modules/esbuild-plugin-copy-file": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-copy-file/-/esbuild-plugin-copy-file-0.0.2.tgz",
+      "integrity": "sha512-pr9CTC68YKClMAusuEy3YlB8EbQIdKWsyCVrEEbskCxKvJ7ZfhFEMesteoJl4daBtcY92gfFt0MsZOwfzZKVmw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,17 +31,15 @@
   },
   "scripts": {
     "serve": "esbuild --bundle --servedir=.",
-    "build": "npm run compile && npm run bundle",
+    "build": "npm run compile && npm run build-literal",
     "compile": "npm run compile:full && npm run compile:ws && npm run compile:http",
-    "compile:full": "wasm-pack build --release --target deno --out-name index --out-dir compiled/full --no-default-features --features protocol-ws,protocol-http,kv-indxdb,kv-mem,rustls",
-    "compile:ws": "wasm-pack build --release --target deno --out-name index --out-dir compiled/ws --no-default-features --features protocol-ws,rustls",
-    "compile:http": "wasm-pack build --release --target deno --out-name index --out-dir compiled/http --no-default-features --features protocol-http,rustls",
-    "bundle": "npm run bundle:full && npm run bundle:ws && npm run bundle:http",
-    "bundle:full": "esbuild --bundle compiled/full/index.js --sourcemap --format=esm --outfile=dist/full/index.js && cp ./compiled/full/index_bg.wasm ./compiled/full/index_bg.wasm ./compiled/full/index_bg.wasm.d.ts ./compiled/full/index.d.ts ./dist/full/",
-    "bundle:ws": "esbuild --bundle compiled/ws/index.js --sourcemap --format=esm --outfile=dist/ws/index.js && cp ./compiled/ws/index_bg.wasm ./compiled/ws/index_bg.wasm ./compiled/ws/index_bg.wasm.d.ts ./compiled/ws/index.d.ts ./dist/ws/",
-    "bundle:http": "esbuild --bundle compiled/http/index.js --sourcemap --format=esm --outfile=dist/http/index.js && cp ./compiled/http/index_bg.wasm ./compiled/http/index_bg.wasm ./compiled/http/index_bg.wasm.d.ts ./compiled/http/index.d.ts ./dist/http/"
+    "compile:full": "wasm-pack build --release --target deno --out-name index --out-dir compiled/full --no-default-features --features protocol-ws,protocol-http,kv-indxdb,kv-mem,rustls,stack-traces",
+    "compile:ws": "wasm-pack build --release --target deno --out-name index --out-dir compiled/ws --no-default-features --features protocol-ws,rustls,stack-traces",
+    "compile:http": "wasm-pack build --release --target deno --out-name index --out-dir compiled/http --no-default-features --features protocol-http,rustls,stack-traces",
+    "build-literal": "node build/index.js"
   },
   "devDependencies": {
-    "esbuild": "^0.17.19"
+    "esbuild": "^0.17.19",
+    "esbuild-plugin-copy-file": "^0.0.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,6 @@
+import { Surreal } from './dist/full/index.js';
+
+const db = new Surreal()
+await db.connect('memory');
+await db.use({ ns: 'test', db: 'test' });
+await db.create('test')


### PR DESCRIPTION
We add some shims to allow this code to also run on NodeJS (at least Node 16 and above)
- A small shim for the Deno global variable (only available within the module)
- If crypto is not broadly available, import it and make it available as a custom web assembly require function