### PR TITLE
Allow loading wasm over any protocol

### DIFF
--- a/build/tauri.patch
+++ b/build/tauri.patch
@@ -2,9 +2,9 @@
     case 'http:':
     wasmCode = await (await fetch(wasm_url)).arrayBuffer();
     break
+    default:
+    throw new Error(`Unsupported protocol: ${wasm_url.protocol}`);
 ===========
-	case "tauri:":
-    case 'https:':
-    case 'http:':
+    default:
     wasmCode = await (await fetch(wasm_url)).arrayBuffer();
     break


### PR DESCRIPTION
The protocol used for fetching wasm binaries should be unrestricted, as certain environments such as Tauri or browser extensions may provide their own. This should be left up to the end user.

Closes #114 